### PR TITLE
为MINGW32/64编译器添加支持

### DIFF
--- a/src/Win/File.cpp
+++ b/src/Win/File.cpp
@@ -195,7 +195,7 @@ namespace hgl
             len=GetCurrentDirectoryW(0,nullptr);
 
             if(len==0)
-                return(nullptr);
+                return false;
 
             dir=new u16char[len+1];
 


### PR DESCRIPTION
这里其实是语法错误，不过MSVC比较容忍